### PR TITLE
Erlang/OTP 24 compatibility (:crypto.hmac -> :crypto.mac)

### DIFF
--- a/lib/json_web_token/algorithm/hmac.ex
+++ b/lib/json_web_token/algorithm/hmac.ex
@@ -18,7 +18,7 @@ defmodule JsonWebToken.Algorithm.Hmac do
   """
   def sign(sha_bits, shared_key, signing_input) do
     validate_params(sha_bits, shared_key)
-    :crypto.hmac(sha_bits, shared_key, signing_input)
+    :crypto.mac(:hmac, sha_bits, shared_key, signing_input)
   end
 
   @doc """


### PR DESCRIPTION
:crypto.hmac/3 was removed in erlang 24 but the same functionality is available in :crypto.mac/4